### PR TITLE
Read api simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LIB_DIR =./lib
 LIBS =${LIB_DIR}/libserial.a ${LIB_DIR}/libcommands.a ${LIB_DIR}/libsupport.a ${LIB_DIR}/libapi.a ${LIB_DIR}/libencryption.a
 EXE =bluefish
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I./cdif -I./ -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I./cdif -I./ -O3
 LD_FLAGS +=-L${LIB_DIR} -lpthread -lcryptopp
 AR_FLAGS +=rcs
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -7,7 +7,7 @@ LIB_DIR =../lib
 OBJS =${OBJ_DIR}/file.o ${OBJ_DIR}/serialization.o ${OBJ_DIR}/binary_api.o ${OBJ_DIR}/wait_ready_api_decorator.o ${OBJ_DIR}/api_module.o
 LIB =${LIB_DIR}/libapi.a
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O3
 AR_FLAGS +=rcs
 
 all: ${LIB}

--- a/api/binary_api.cpp
+++ b/api/binary_api.cpp
@@ -84,25 +84,17 @@ either<Success, APIFailureReason> BinaryAPI::write_file(const File& file)
 
 either<File, APIFailureReason> BinaryAPI::read_file(const std::string& filename)
 {
-    return get_file_id(filename)
-        .foldFirst(
-            [&] (const auto& id) -> either<File, APIFailureReason> {
-                return wait_ready()
-                    .foldFirst(
-                        [&] (auto&&) -> either<File, APIFailureReason> {
-                            _device << Command::ReadFile << id;
+    _device << Command::ReadFile << filename;
 
-                            CommandStatus status;
-                            _device >> status;
+    CommandStatus status;
+    _device >> status;
 
-                            if (status != CommandStatus::OK)
-                                return convert_status(status);
+    if (status != CommandStatus::OK)
+        return convert_status(status);
 
-                            File file;
-                            _device >> file;
-                            return file;
-                        });
-            });
+    File file;
+    _device >> file;
+    return file;
 }
 
 std::vector<FileId> BinaryAPI::list_ids()

--- a/commands/Makefile
+++ b/commands/Makefile
@@ -11,7 +11,7 @@ OBJS =${OBJ_DIR}/add_file_command.o ${OBJ_DIR}/format_command.o \
 	  ${OBJ_DIR}/challenge_verifier.o
 LIB =${LIB_DIR}/libcommands.a
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O3
 AR_FLAGS +=rcs
 
 all: ${LIB}

--- a/encryption/Makefile
+++ b/encryption/Makefile
@@ -7,7 +7,7 @@ LIB_DIR =../lib
 OBJS =${OBJ_DIR}/encryption_helpers.o ${OBJ_DIR}/encryption.o ${OBJ_DIR}/encryption_module.o
 LIB =${LIB_DIR}/libencryption.a
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../cdif -I../ -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../cdif -I../ -O3
 AR_FLAGS +=rcs
 
 all: ${LIB}

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -7,7 +7,7 @@ LIB_DIR =../lib
 OBJS =${OBJ_DIR}/serial_device.o ${OBJ_DIR}/serial_module.o
 LIB =${LIB_DIR}/libserial.a
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../cdif -I../ -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../cdif -I../ -O3
 AR_FLAGS +=rcs
 
 all: ${LIB}

--- a/support/Makefile
+++ b/support/Makefile
@@ -7,7 +7,7 @@ LIB_DIR =../lib
 OBJS =${OBJ_DIR}/argument_parsing.o ${OBJ_DIR}/failure_reason_translator.o ${OBJ_DIR}/support_module.o ${OBJ_DIR}/askpass.o
 LIB =${LIB_DIR}/libsupport.a
 
-CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O0
+CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O3
 AR_FLAGS +=rcs
 
 all: ${LIB}


### PR DESCRIPTION
Simplify read API to offload comparison of filename to files found to the device. This makes the whole operation faster as the device doesn't have to send back all the filenames it found; but can check them as it finds them.