### PR TITLE
Reset Hardware Before Transmissions

### DIFF
--- a/serial/serial_device.cpp
+++ b/serial/serial_device.cpp
@@ -5,11 +5,20 @@
 #include <algorithm>
 #include <iostream>
 #include <utility>
+#include <sys/ioctl.h>
 
 #include <boost/bind.hpp>
 
 using namespace std;
 using namespace boost;
+
+void SerialDevice::toggleRTS()
+{
+    auto fd = port.native_handle();
+    auto data = TIOCM_RTS;
+    ioctl(fd, TIOCMBIS, &data);
+    ioctl(fd, TIOCMBIC, &data);
+}
 
 bool SerialDevice::isOpen() const
 {

--- a/serial/serial_device.h
+++ b/serial/serial_device.h
@@ -36,8 +36,11 @@ public:
         port.set_option(opt_csize);
         port.set_option(opt_flow);
         port.set_option(opt_stop);
+
+        toggleRTS();
     }
 
+    void toggleRTS();
     bool isOpen() const override;
     void close() override;
     void write(const char *data, size_t size) override;


### PR DESCRIPTION
Previously the client would wait for the hardware to send a ready signal
before attempting any communications. This previously relied on the fact
that connecting with boost asio would toggle the DTR line. When the
hardware was commited to use the CH330N chip it removed the DTR line but
left available a RTS line. This change toggles the RTS line after
connect to reset the device.