### PR TITLE
Add Rename File Command

### DIFF
--- a/commands/Makefile
+++ b/commands/Makefile
@@ -8,7 +8,7 @@ OBJS =${OBJ_DIR}/add_file_command.o ${OBJ_DIR}/format_command.o \
 	  ${OBJ_DIR}/list_files_command.o ${OBJ_DIR}/read_file_command.o \
 	  ${OBJ_DIR}/remove_file_command.o ${OBJ_DIR}/command_composite.o \
 	  ${OBJ_DIR}/print_usage_command.o ${OBJ_DIR}/commands_module.o \
-	  ${OBJ_DIR}/challenge_verifier.o
+	  ${OBJ_DIR}/rename_file_command.o ${OBJ_DIR}/challenge_verifier.o
 LIB =${LIB_DIR}/libcommands.a
 
 CXX_FLAGS +=--std=c++17 -Wall -Wextra -pedantic -Werror -I../ -I../cdif -O3

--- a/commands/commands_module.cpp
+++ b/commands/commands_module.cpp
@@ -10,6 +10,7 @@
 #include "commands/print_usage_command.h"
 #include "commands/read_file_command.h"
 #include "commands/remove_file_command.h"
+#include "commands/rename_file_command.h"
 #include "encryption/encryption.h"
 #include "support/failure_reason_translator.h"
 
@@ -33,6 +34,9 @@ void CommandsModule::load(cdif::Container& container)
         .bind<RemoveFileCommand, API&, FailureReasonTranslator&, ChallengeVerifier&, Encrypter&>()
         .build();
     container
+        .bind<RenameFileCommand, API&, FailureReasonTranslator&, ChallengeVerifier&, Encrypter&>()
+        .build();
+    container
         .bind<PrintUsageCommand, API&, FailureReasonTranslator&>()
         .build();
 
@@ -42,6 +46,7 @@ void CommandsModule::load(cdif::Container& container)
             std::unique_ptr<RemoveFileCommand>,
             std::unique_ptr<ReadFileCommand>,
             std::unique_ptr<ListFilesCommand>,
+            std::unique_ptr<RenameFileCommand>,
             std::unique_ptr<PrintUsageCommand>>()
         .build();
 

--- a/commands/rename_file_command.cpp
+++ b/commands/rename_file_command.cpp
@@ -1,0 +1,69 @@
+#include "commands/rename_file_command.h"
+
+#include "api/api.h"
+#include "support/arguments.h"
+#include "support/askpass.h"
+
+#include <iostream>
+#include <string>
+
+bool RenameFileCommand::matches(const Arguments& arguments) const
+{
+    using namespace std::string_literals;
+    return arguments.rename_file != ""s && arguments.new_file_name != ""s;
+}
+
+void RenameFileCommand::execute(const Arguments& arguments)
+{
+    auto master_password = askpass("Master Password: ");
+
+    MasterBlock master_block;
+
+    _challenge_verifier.verify(std::string(master_password))
+        .foldFirst([&] (const auto& mb) {
+            master_block = mb;
+
+            auto filename = _encrypter.encrypt(
+                std::string(arguments.rename_file),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.read_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto& file) {
+            auto new_file = file;
+            auto new_file_name = _encrypter.encrypt(
+                std::string(arguments.new_file_name),
+                std::string(master_password),
+                master_block.encryption_iv);
+            new_file.name = new_file_name;
+
+            return _api.write_file(new_file)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto&) {
+            auto filename = _encrypter.encrypt(
+                std::string(arguments.rename_file),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.remove_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .match(
+            [] (const auto&) -> void {},
+            [&] (const auto& failure_reason) -> void {
+                std::cout << _failure_reason_translator.to_string(failure_reason) << std::endl;
+        });
+}
+

--- a/commands/rename_file_command.h
+++ b/commands/rename_file_command.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "api/api.h"
+#include "commands/command.h"
+#include "commands/challenge_verifier.h"
+#include "encryption/encryption.h"
+#include "support/arguments.h"
+#include "support/failure_reason_translator.h"
+
+class RenameFileCommand : public Command
+{
+    private:
+        API& _api;
+        FailureReasonTranslator& _failure_reason_translator;
+        ChallengeVerifier& _challenge_verifier;
+        Encrypter& _encrypter;
+
+    public:
+        RenameFileCommand(
+            API& api,
+            FailureReasonTranslator& frt,
+            ChallengeVerifier& cv,
+            Encrypter& enc)
+            :
+            _api(api),
+            _failure_reason_translator(frt),
+            _challenge_verifier(cv),
+            _encrypter(enc)
+        {}
+
+        void execute(const Arguments& arguments) override;
+        bool matches(const Arguments& arguments) const override;
+};

--- a/support/argument_parsing.cpp
+++ b/support/argument_parsing.cpp
@@ -54,6 +54,18 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             { "-r"s, "--read"s },
             "Read a file from storage"s)
         .add_optional(
+            "rename_file"s,
+            &Arguments::rename_file,
+            ""s,
+            { "-e"s, "--rename"s },
+            "Rename a file to `new_file_name`"s)
+        .add_optional(
+            "new_file_name"s,
+            &Arguments::new_file_name,
+            ""s,
+            { "-n"s, "--new-file"s },
+            "New name for file being renamed"s)
+        .add_optional(
             "format"s,
             &Arguments::format,
             false,

--- a/support/arguments.h
+++ b/support/arguments.h
@@ -13,6 +13,10 @@ struct Arguments
 
     std::string remove_file;
     std::string read_file;
+
+    std::string rename_file;
+    std::string new_file_name;
+
     bool format;
     bool print_usage;
 };


### PR DESCRIPTION
Adds ability to rename a file without having to manually
read/create/delete. This is purely client side driven and requires no
API changes. The new file is created before the old is delete to reduce
the chance of loosing data; additionally the old file is not deleted if
the new file is not created