### PR TITLE
Change Username and Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ make
 ## Usage
 
 ```
-Usage: ./bluefish [-d|--device <device>] [-b|--baud <baud>] [-l|--list] [-a|--add <add_file>] [-u|--username <username>] [--remove|--rm <remove>] [-r|--read <read>] [-e|--rename <rename_file>] [-n|--new-file <new_file_name>] [-f|--format] [-p|--print-usage] [--backup <backup_file>] [--restore <restore_file>]
+Usage: ./bluefish [-d|--device <device>] [-b|--baud <baud>] [-l|--list] [-a|--add <filename>] [-u|--username <username>] [--remove|--rm <filename>] [-r|--read <filename>] [-A|--rename <rename_from>] [-n|--new-file <rename_to>] [-U|--change-username <filename>] [-P|--change-password <filename>] [-f|--format] [-p|--print-usage] [--backup <filename>] [--restore <filename>] [--verify <filename>]
 ```
 
 
@@ -95,7 +95,7 @@ as well as their contents.
 `-a|--add <filename>` - Specifies the filename for the file to add. This needs
 to be used with the `-u|--username` flag.
 
-`-u|--username <useranme>` - Specifies the username portion of the credentials
+`-u|--username <username>` - Specifies the username portion of the credentials
 to associate with this file.
 
 After specifying these two flags and values, you'll be asked for the password
@@ -129,16 +129,34 @@ the filenames were).
 
 ### Renaming a file
 
-`-e|--rename <rename_file> -n|--new-file <new_file_name>` - Renames `rename_file`
-to `new_file_name`.
+`-A|--rename <rename_from> -n|--new-file <rename_to>` - Renames `rename_from`
+to `rename_to`.
 
 Just what it sounds like, this renames a file without modifying its contents,
 other than the filename.
 
 
+### Changing a username
+
+`-U|--change-username <filename> -u|--username <username>` - Changes the
+username for the file `filename` to `username`.
+
+Allows you to change the username of a file. You will be prompted for the
+master password.
+
+
+### Changing a password
+
+`-P|--change-password <filename>` - Changes the password for the
+file `filename`.
+
+Allows you to change the password of a filename. You will be prompted for the
+master password and the new password.
+
+
 ### Backup device contents to file
 
-`--backup <backup_file>` - backs up all data on the device to the local file
+`--backup <filename>` - backs up all data on the device to the local file
 `backup_file`.
 
 This will create a local file `backup_file` containing all the contents of the
@@ -147,12 +165,21 @@ the same as the device itself is, so even if a bad actor got ahold of it, they
 can't read the contents without your master password.
 
 
-## Restoring a backup file
+### Restoring a backup file
 
-`--restore <restore_file>` - Restores the contents of a backup file to the device
+`--restore <filename>` - Restores the contents of a backup file to the device
 
 This will overwrite any data currently on the device, but it will prompt you
 first to make sure this is really what you want to do.
+
+
+### Verifying a backup file
+
+`--verify <filename>` - Verify the contents of a backup file to ensure it
+is not corrupt.
+
+This will print some general information about the file if it is intact, and an
+error message otherwise.
 
 
 ### How much storage is left?

--- a/commands/Makefile
+++ b/commands/Makefile
@@ -10,6 +10,7 @@ OBJS =${OBJ_DIR}/add_file_command.o ${OBJ_DIR}/format_command.o \
 	  ${OBJ_DIR}/rename_file_command.o ${OBJ_DIR}/challenge_verifier.o \
 	  ${OBJ_DIR}/create_backup_command.o ${OBJ_DIR}/restore_backup_command.o \
 	  ${OBJ_DIR}/print_usage_command.o ${OBJ_DIR}/verify_backup_command.o \
+	  ${OBJ_DIR}/change_password_command.o ${OBJ_DIR}/change_username_command.o \
 	  ${OBJ_DIR}/commands_module.o
 
 LIB =${LIB_DIR}/libcommands.a

--- a/commands/change_password_command.cpp
+++ b/commands/change_password_command.cpp
@@ -1,0 +1,66 @@
+#include "commands/change_password_command.h"
+
+#include "api/api.h"
+#include "api/master_block.h"
+#include "support/arguments.h"
+#include "support/askpass.h"
+
+#include <iostream>
+#include <string>
+
+bool ChangePasswordCommand::matches(const Arguments& arguments) const
+{
+    using namespace std::string_literals;
+    return arguments.change_password_file != ""s;
+}
+
+void ChangePasswordCommand::execute(const Arguments& arguments)
+{
+    auto master_password = askpass("Master Password: ");
+
+    MasterBlock master_block;
+    std::string filename;
+    File new_file;
+
+    _challenge_verifier.verify(std::string(master_password))
+        .foldFirst([&] (const auto& mb) {
+            master_block = mb;
+
+            filename = _encrypter.encrypt(
+                std::string(arguments.change_password_file),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.read_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto& file) {
+            new_file = file;
+            new_file.password = _encrypter.encrypt(
+                askpass(),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.remove_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto&) {
+            return _api.write_file(new_file)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .match(
+            [] (const auto&) -> void {},
+            [&] (const auto& failure_reason) -> void {
+                std::cout << _failure_reason_translator.to_string(failure_reason) << std::endl;
+        });
+}
+

--- a/commands/change_password_command.h
+++ b/commands/change_password_command.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "api/api.h"
+#include "commands/command.h"
+#include "commands/challenge_verifier.h"
+#include "encryption/encryption.h"
+#include "support/arguments.h"
+#include "support/failure_reason_translator.h"
+
+class ChangePasswordCommand : public Command
+{
+    private:
+        API& _api;
+        FailureReasonTranslator& _failure_reason_translator;
+        ChallengeVerifier& _challenge_verifier;
+        Encrypter& _encrypter;
+
+    public:
+        ChangePasswordCommand(
+            API& api,
+            FailureReasonTranslator& frt,
+            ChallengeVerifier& cv,
+            Encrypter& enc)
+            :
+            _api(api),
+            _failure_reason_translator(frt),
+            _challenge_verifier(cv),
+            _encrypter(enc)
+        {}
+
+        void execute(const Arguments& arguments) override;
+        bool matches(const Arguments& arguments) const override;
+};

--- a/commands/change_username_command.cpp
+++ b/commands/change_username_command.cpp
@@ -1,0 +1,66 @@
+#include "commands/change_username_command.h"
+
+#include "api/api.h"
+#include "api/master_block.h"
+#include "support/arguments.h"
+#include "support/askpass.h"
+
+#include <iostream>
+#include <string>
+
+bool ChangeUsernameCommand::matches(const Arguments& arguments) const
+{
+    using namespace std::string_literals;
+    return arguments.change_username_file != ""s && arguments.username != ""s;
+}
+
+void ChangeUsernameCommand::execute(const Arguments& arguments)
+{
+    auto master_password = askpass("Master Password: ");
+
+    MasterBlock master_block;
+    std::string filename;
+    File new_file;
+
+    _challenge_verifier.verify(std::string(master_password))
+        .foldFirst([&] (const auto& mb) {
+            master_block = mb;
+
+            filename = _encrypter.encrypt(
+                std::string(arguments.change_username_file),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.read_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto& file) {
+            new_file = file;
+            new_file.username = _encrypter.encrypt(
+                std::string(arguments.username),
+                std::string(master_password),
+                master_block.encryption_iv);
+
+            return _api.remove_file(filename)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .foldFirst([&] (const auto&) {
+            return _api.write_file(new_file)
+                .mapSecond(
+                    [&] (const APIFailureReason& failure) -> FailureReason {
+                        return _failure_reason_translator.translate(failure);
+                });
+        })
+        .match(
+            [] (const auto&) -> void {},
+            [&] (const auto& failure_reason) -> void {
+                std::cout << _failure_reason_translator.to_string(failure_reason) << std::endl;
+        });
+}
+

--- a/commands/change_username_command.h
+++ b/commands/change_username_command.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "api/api.h"
+#include "commands/command.h"
+#include "commands/challenge_verifier.h"
+#include "encryption/encryption.h"
+#include "support/arguments.h"
+#include "support/failure_reason_translator.h"
+
+class ChangeUsernameCommand : public Command
+{
+    private:
+        API& _api;
+        FailureReasonTranslator& _failure_reason_translator;
+        ChallengeVerifier& _challenge_verifier;
+        Encrypter& _encrypter;
+
+    public:
+        ChangeUsernameCommand(
+            API& api,
+            FailureReasonTranslator& frt,
+            ChallengeVerifier& cv,
+            Encrypter& enc)
+            :
+            _api(api),
+            _failure_reason_translator(frt),
+            _challenge_verifier(cv),
+            _encrypter(enc)
+        {}
+
+        void execute(const Arguments& arguments) override;
+        bool matches(const Arguments& arguments) const override;
+};

--- a/commands/commands_module.cpp
+++ b/commands/commands_module.cpp
@@ -3,6 +3,8 @@
 #include "cdif/cdif.h"
 #include "commands/add_file_command.h"
 #include "commands/challenge_verifier.h"
+#include "commands/change_username_command.h"
+#include "commands/change_password_command.h"
 #include "commands/command_composite.h"
 #include "commands/command.h"
 #include "commands/create_backup_command.h"
@@ -51,6 +53,12 @@ void CommandsModule::load(cdif::Container& container)
     container
         .bind<VerifyBackupCommand, FailureReasonTranslator&>()
         .build();
+    container
+        .bind<ChangePasswordCommand, API&, FailureReasonTranslator&, ChallengeVerifier&, Encrypter&>()
+        .build();
+    container
+        .bind<ChangeUsernameCommand, API&, FailureReasonTranslator&, ChallengeVerifier&, Encrypter&>()
+        .build();
 
     container.bindList<std::unique_ptr<Command>,
             std::unique_ptr<FormatCommand>,
@@ -62,7 +70,9 @@ void CommandsModule::load(cdif::Container& container)
             std::unique_ptr<PrintUsageCommand>,
             std::unique_ptr<CreateBackupCommand>,
             std::unique_ptr<RestoreBackupCommand>,
-            std::unique_ptr<VerifyBackupCommand>>()
+            std::unique_ptr<VerifyBackupCommand>,
+            std::unique_ptr<ChangePasswordCommand>,
+            std::unique_ptr<ChangeUsernameCommand>>()
         .build();
 
     container

--- a/support/argument_parsing.cpp
+++ b/support/argument_parsing.cpp
@@ -66,6 +66,18 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             { "-n"s, "--new-file"s },
             "New name for file being renamed"s)
         .add_optional(
+            "filename"s,
+            &Arguments::change_username_file,
+            ""s,
+            { "-U"s, "--change-username"s },
+            "Change username for given file. Use in conjuction with -u|--username"s)
+        .add_optional(
+            "filename"s,
+            &Arguments::change_password_file,
+            ""s,
+            { "-P"s, "--change-password"s },
+            "Change password for given file"s)
+        .add_optional(
             "format"s,
             &Arguments::format,
             false,

--- a/support/argument_parsing.cpp
+++ b/support/argument_parsing.cpp
@@ -30,7 +30,7 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             { "-l"s, "--list"s },
             "List files from device"s)
         .add_optional(
-            "add_file"s,
+            "filename"s,
             &Arguments::add_file,
             ""s,
             { "-a"s, "--add"s },
@@ -40,31 +40,31 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             &Arguments::username,
             ""s,
             { "-u"s, "--username"s },
-            "Username for file to add (used with --add)"s)
+            "Username for file to add. Use in conjuction with -a|--add"s)
         .add_optional(
-            "remove"s,
+            "filename"s,
             &Arguments::remove_file,
             ""s,
             { "--remove"s, "--rm"s },
             "Remove file from storage"s)
         .add_optional(
-            "read"s,
+            "filename"s,
             &Arguments::read_file,
             ""s,
             { "-r"s, "--read"s },
             "Read a file from storage"s)
         .add_optional(
-            "rename_file"s,
+            "rename_from"s,
             &Arguments::rename_file,
             ""s,
-            { "-e"s, "--rename"s },
-            "Rename a file to `new_file_name`"s)
+            { "-A"s, "--rename"s },
+            "Renames a file from `rename_from` to `rename_to`. Use in conjuction with -n|--new-file"s)
         .add_optional(
-            "new_file_name"s,
+            "rename_to"s,
             &Arguments::new_file_name,
             ""s,
             { "-n"s, "--new-file"s },
-            "New name for file being renamed"s)
+            "New name for file being renamed. Use in conjuction with -A|--rename"s)
         .add_optional(
             "filename"s,
             &Arguments::change_username_file,
@@ -90,19 +90,19 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             { "-p"s, "--print-usage"s },
             "Print disk usage"s)
         .add_optional(
-            "backup_file"s,
+            "filename"s,
             &Arguments::backup_file,
             ""s,
             { "--backup"s },
             "Backup data from device to local filesystem"s)
         .add_optional(
-            "restore_file"s,
+            "filename"s,
             &Arguments::restore_file,
             ""s,
             { "--restore"s },
             "Restore backup file to device"s)
         .add_optional(
-            "verify_backup"s,
+            "filename"s,
             &Arguments::verify,
             ""s,
             { "--verify"s },

--- a/support/arguments.h
+++ b/support/arguments.h
@@ -16,6 +16,8 @@ struct Arguments
 
     std::string rename_file;
     std::string new_file_name;
+    std::string change_password_file;
+    std::string change_username_file;
 
     bool format;
     bool print_usage;


### PR DESCRIPTION
Adds commands that allow changing the username and password of existing files.

Cleans up usages of `filename` in the arguments and README to be more uniform unless more specific names are necessary.

Cleans up flags used to signify options to commands. Makes the flag choices more intuitive.