### PR TITLE
Add Retry to Master Password Prompts

### DIFF
--- a/commands/add_file_command.cpp
+++ b/commands/add_file_command.cpp
@@ -19,12 +19,12 @@ void AddFileCommand::execute(const Arguments& arguments)
     }
 
     auto password = askpass();
-    auto master_password = askpass("Master Password: ");
 
-    _challenge_verifier.verify(std::string(master_password))
+    _challenge_verifier.verify()
         .match(
-            [&] (const auto& master_block)
+            [&] (auto&& result)
             {
+                auto& [master_block, master_password] = result;
                 auto encrypted_filename = _encrypter.encrypt(
                         std::string(arguments.add_file),
                         std::string(master_password),

--- a/commands/challenge_verifier.cpp
+++ b/commands/challenge_verifier.cpp
@@ -1,35 +1,50 @@
 #include "challenge_verifier.h"
 
+#include <optional>
 #include <string>
+#include <tuple>
 
 #include "either/either.h"
 #include "api/api.h"
 #include "api/master_block.h"
+#include "support/askpass.h"
 #include "support/failure_reason.h"
 
-either<MasterBlock, FailureReason> ChallengeVerifier::verify(std::string&& password)
+either<std::string, FailureReason> ChallengeVerifier::verify_entered_password(const MasterBlock& master_block) const
+{
+    auto password = std::string{};
+    auto failure = std::optional<FailureReason>{};
+    for (auto attempt = 0; (attempt < 3 && failure) || attempt == 0; attempt++)
+    {
+        password = askpass("Master Password: ");
+        failure = _decrypter.decrypt(
+                master_block.challenge,
+                std::string(password),
+                master_block.encryption_iv)
+            .match(
+                [&] (auto&&) -> decltype(failure) { return {}; },
+                [&] (auto&& f) -> decltype(failure) { return _failure_reason_translator.translate(f); });
+    }
+
+    if (failure)
+        return failure.value();
+    return password;
+}
+
+either<std::tuple<MasterBlock, std::string>, FailureReason> ChallengeVerifier::verify() const
 {
     return _api.get_master_block()
         .match(
-            [&] (auto&& master_block) -> either<MasterBlock, FailureReason>
+            [&] (auto&& master_block) -> either<std::tuple<MasterBlock, std::string>, FailureReason>
             {
-                auto challenge = master_block.challenge;
-                return _decrypter.decrypt(
-                        challenge,
-                        std::move(password),
-                        master_block.encryption_iv)
-                    .match(
-                        [&] (auto&&) -> either<MasterBlock, FailureReason>
+                return verify_entered_password(master_block)
+                    .mapFirst(
+                        [&] (auto&& password)
                         {
-                            return master_block;
-                        },
-                        [&] (auto&& failure) -> either<MasterBlock, FailureReason>
-                        {
-                            return _failure_reason_translator.translate(failure);
-                        }
-                    );
+                            return std::make_tuple(std::move(master_block), password);
+                        });
             },
-            [&] (auto&& failure) -> either<MasterBlock, FailureReason>
+            [&] (auto&& failure) -> either<std::tuple<MasterBlock, std::string>, FailureReason>
             {
                 return _failure_reason_translator.translate(failure);
             });

--- a/commands/challenge_verifier.h
+++ b/commands/challenge_verifier.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <tuple>
+
 #include "encryption/encryption.h"
 #include "api/api.h"
 #include "api/master_block.h"
@@ -14,9 +16,10 @@ class ChallengeVerifier
         Decrypter& _decrypter;
         FailureReasonTranslator& _failure_reason_translator;
 
+        either<std::string, FailureReason> verify_entered_password(const MasterBlock& master_block) const;
     public:
         ChallengeVerifier(API& api, Decrypter& dec, FailureReasonTranslator& frt)
             : _api(api), _decrypter(dec), _failure_reason_translator(frt) {}
 
-        either<MasterBlock, FailureReason> verify(std::string&& password);
+        either<std::tuple<MasterBlock, std::string>, FailureReason> verify() const;
 };

--- a/commands/change_username_command.cpp
+++ b/commands/change_username_command.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <tuple>
 
 bool ChangeUsernameCommand::matches(const Arguments& arguments) const
 {
@@ -16,14 +17,13 @@ bool ChangeUsernameCommand::matches(const Arguments& arguments) const
 
 void ChangeUsernameCommand::execute(const Arguments& arguments)
 {
-    auto master_password = askpass("Master Password: ");
-
     MasterBlock master_block;
     std::string filename;
     File new_file;
 
-    _challenge_verifier.verify(std::string(master_password))
-        .foldFirst([&] (const auto& mb) {
+    _challenge_verifier.verify()
+        .foldFirst([&] (auto&& result) {
+            auto& [mb, master_password] = result;
             master_block = mb;
 
             filename = _encrypter.encrypt(
@@ -32,12 +32,15 @@ void ChangeUsernameCommand::execute(const Arguments& arguments)
                 master_block.encryption_iv);
 
             return _api.read_file(filename)
-                .mapSecond(
+                .mapFirst(
+                    [&] (const auto& file) { return std::make_tuple(file, std::move(master_password)); }
+                ).mapSecond(
                     [&] (const APIFailureReason& failure) -> FailureReason {
                         return _failure_reason_translator.translate(failure);
                 });
         })
-        .foldFirst([&] (const auto& file) {
+        .foldFirst([&] (auto&& result) {
+            auto& [file, master_password] = result;
             new_file = file;
             new_file.username = _encrypter.encrypt(
                 std::string(arguments.username),

--- a/commands/create_backup_command.cpp
+++ b/commands/create_backup_command.cpp
@@ -24,9 +24,9 @@ void CreateBackupCommand::execute(const Arguments& args)
     MasterBlock master_block;
     std::vector<File> files;
 
-    auto master_password = askpass("Master Password: ");
-    _challenge_verifier.verify(std::move(master_password))
-        .foldFirst([&] (const auto& mb) {
+    _challenge_verifier.verify()
+        .foldFirst([&] (auto&& result) {
+            auto& [mb, mp] = result;
             master_block = mb;
             return _api.list_files()
                 .mapSecond([&] (const APIFailureReason& failure) -> FailureReason {

--- a/commands/list_files_command.cpp
+++ b/commands/list_files_command.cpp
@@ -13,10 +13,10 @@
 
 void ListFilesCommand::execute(const Arguments&)
 {
-    auto master_password = askpass("Master Password: ");
-    _challenge_verifier.verify(std::string(master_password))
+    _challenge_verifier.verify()
         .match(
-            [&] (const auto& master_block) {
+            [&] (auto&& result) {
+                auto& [master_block, master_password] = result;
                 _api.list_files()
                     .match(
                         [&] (auto&& encrypted_filenames) {

--- a/commands/read_file_command.cpp
+++ b/commands/read_file_command.cpp
@@ -10,11 +10,11 @@
 
 void ReadFileCommand::execute(const Arguments& arguments)
 {
-    auto master_password = askpass("Master Password: ");
-    _challenge_verifier.verify(std::string(master_password))
+    _challenge_verifier.verify()
         .match(
-            [&] (const auto& master_block)
+            [&] (auto&& result)
             {
+                auto& [master_block, master_password] = result;
                 auto filename = _encrypter.encrypt(
                     std::string(arguments.read_file),
                     std::string(master_password),

--- a/commands/remove_file_command.cpp
+++ b/commands/remove_file_command.cpp
@@ -9,14 +9,13 @@
 
 void RemoveFileCommand::execute(const Arguments& arguments)
 {
-    auto master_password = askpass("Master Password: ");
-
-    _challenge_verifier.verify(std::string(master_password))
+    _challenge_verifier.verify()
         .match(
-            [&] (const auto& master_block) {
+            [&] (auto&& result) {
+                auto& [master_block, master_password] = result;
                 auto filename = _encrypter.encrypt(
                     std::string(arguments.remove_file),
-                    std::string(master_password),
+                    std::move(master_password),
                     master_block.encryption_iv);
 
                 _api.remove_file(filename)
@@ -30,8 +29,6 @@ void RemoveFileCommand::execute(const Arguments& arguments)
             [&] (const auto& failure_reason) {
                 std::cout << _failure_reason_translator.to_string(failure_reason) << std::endl;
             });
-
-    clear_data(master_password);
 }
 
 bool RemoveFileCommand::matches(const Arguments& arguments) const


### PR DESCRIPTION
Previously the program would exit if the master password was entered
incorrectly a single time causing the user to go back and re-enter all
information. This was particularly annoying when entering a new password
file. This solves the issue by allowing up to 3 failed passwords before
exiting the program.